### PR TITLE
docs: fix typo, DCO as plain text

### DIFF
--- a/DCO
+++ b/DCO
@@ -1,16 +1,3 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
-<html>
-<!--
-    File:   index.html
-    Editor: None, you wimpy wysiwyg people...this is hand crafted!
-            What are you doing reading this anyway???
--->
-<head>
-	<title>Developer Certificate of Origin</title>
-</head>
-
-<body>
-<pre>
 Developer Certificate of Origin
 Version 1.1
 
@@ -48,7 +35,3 @@ By making a contribution to this project, I certify that:
     personal information I submit with it, including my sign-off) is
     maintained indefinitely and may be redistributed consistent with
     this project or the open source license(s) involved.
-</pre>
-
-</body>
-</html>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `multihealthcheck` is a health check aggregator.
 
-When `multihealtcheck` receives an http request, it makes parallel requests in
+When `multihealthcheck` receives an http request, it makes parallel requests in
 turn to the configured http/https health check targets. If all the defined
 health checks are OK, it returns a 200 OK. Otherwise, it returns a 500 DOWN.
 
@@ -27,4 +27,4 @@ an afternoon building something similar.
 This project is licensed under the [Apache License, Version 2.0](LICENSE).
 
 Please include a `Signed-off-by` in all commits, per
-[Developer Certificate of Origin version 1.1](DCO.html).
+[Developer Certificate of Origin version 1.1](DCO).


### PR DESCRIPTION
Having the DCO as the upstream `.html` file resulted in a sub-optimal experience in the GitHub web interface.

Signed-off-by: Erik Swanson <erik@retailnext.net>